### PR TITLE
chore(workflow): add templates, ci, and learning automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/chapter.yml
+++ b/.github/ISSUE_TEMPLATE/chapter.yml
@@ -1,0 +1,67 @@
+name: Learning Chapter
+about: Track one learning chapter from implementation to retrospective
+title: "[Chapter] Phase X - Framework - Chapter Y"
+labels: ["chapter", "learning"]
+body:
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      options:
+        - Phase 1: App Frameworks
+        - Phase 2: App Services
+        - Phase 3: Graphics & Media
+        - Phase 4: System & Network
+        - Phase 5: iOS 26
+    validations:
+      required: true
+
+  - type: input
+    id: framework
+    attributes:
+      label: Framework
+      placeholder: e.g. SwiftUI
+    validations:
+      required: true
+
+  - type: input
+    id: chapter
+    attributes:
+      label: Chapter
+      placeholder: e.g. Chapter 1
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Learning Goals
+      description: What will be completed in this chapter?
+      placeholder: |
+        - Build ...
+        - Understand ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Task Checklist
+      value: |
+        - [ ] Implement chapter code
+        - [ ] Run build/test checks
+        - [ ] Open PR and request review
+        - [ ] Merge and write Velog retrospective
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of Done
+      placeholder: |
+        - UI works as intended
+        - CI passes
+        - Retrospective link added
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Discussion
+    url: https://github.com/YuSeongChoi/HIGLab/discussions
+    about: Ask questions or discuss learning approaches.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+- 
+
+## Why
+- 
+
+## Scope
+- [ ] `practice/HIGPractice/**`
+- [ ] Other: 
+
+## Issue
+- Closes #
+
+## Testing
+- [ ] Local build passes
+- [ ] Key flow manually verified
+
+```bash
+# Example
+xcodebuild -project practice/HIGPractice/HIGPractice.xcodeproj \
+  -scheme HIGPractice \
+  -destination 'generic/platform=iOS' \
+  -derivedDataPath /tmp/HIGPracticeDerived \
+  CODE_SIGNING_ALLOWED=NO build
+```
+
+## Checklist
+- [ ] Conventional commit title used
+- [ ] Docs updated (`README` / `CONTRIBUTING` / `LEARNING_LOG` as needed)
+- [ ] CI checks pass
+- [ ] Reviewer concerns addressed
+
+## Screenshots / Recordings
+- 
+
+## Retrospective (Optional)
+- What I learned:
+- What to improve next chapter:

--- a/.github/scripts/protect_main_branch.sh
+++ b/.github/scripts/protect_main_branch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-YuSeongChoi/HIGLab}"
+BRANCH="${2:-main}"
+REQUIRED_CHECK="${3:-Build HIGPractice (iOS 26)}"
+
+# Requires admin permission on the repository.
+# Usage:
+#   .github/scripts/protect_main_branch.sh YuSeongChoi/HIGLab main "Build HIGPractice (iOS 26)"
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --input - <<JSON
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "${REQUIRED_CHECK}"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+
+echo "Branch protection applied: ${REPO}:${BRANCH}"

--- a/.github/scripts/setup_labels.sh
+++ b/.github/scripts/setup_labels.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-YuSeongChoi/HIGLab}"
+
+create_or_update_label() {
+  local name="$1"
+  local color="$2"
+  local desc="$3"
+
+  if gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" 2>/dev/null; then
+    echo "created: $name"
+  else
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc"
+    echo "updated: $name"
+  fi
+}
+
+create_or_update_label "learning" "1D76DB" "Learning task"
+create_or_update_label "chapter" "0E8A16" "Single chapter scoped work"
+create_or_update_label "retrospective" "5319E7" "Post-learning retrospective"
+create_or_update_label "needs-review" "FBCA04" "Needs code review"
+create_or_update_label "phase-1" "0052CC" "Phase 1: App Frameworks"
+create_or_update_label "phase-2" "1D76DB" "Phase 2: App Services"
+create_or_update_label "phase-3" "5319E7" "Phase 3: Graphics & Media"
+create_or_update_label "phase-4" "C2E0C6" "Phase 4: System & Network"
+create_or_update_label "phase-5" "B60205" "Phase 5: iOS 26"
+
+echo "Label setup complete for $REPO"

--- a/.github/workflows/learning-log-reminder.yml
+++ b/.github/workflows/learning-log-reminder.yml
@@ -1,0 +1,49 @@
+name: Learning Log Reminder
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  remind:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post merged PR learning log template
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const today = new Date().toISOString().slice(0, 10);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prRef = `#${pr.number}`;
+            const issueMatch = (pr.body || '').match(/#(\d+)/);
+            const issueRef = issueMatch ? `#${issueMatch[1]}` : '#<issue-number>';
+
+            const body = [
+              'Learning log template for this merged PR:',
+              '',
+              '| Date | Phase | Framework | Chapter | Issue | PR | Velog | Key Learning |',
+              '|---|---|---|---|---|---|---|---|',
+              `| ${today} | Phase <n> | <Framework> | Chapter <n> | ${issueRef} | ${prRef} | https://velog.io/@... | <one key learning> |`,
+              '',
+              'Quick add command:',
+              '```bash',
+              `scripts/add_learning_log.sh --date ${today} --phase "Phase <n>" --framework "<Framework>" --chapter "Chapter <n>" --issue "${issueRef}" --pr "${prRef}" --velog "https://velog.io/@..." --key "<one key learning>"`,
+              '```',
+              '',
+              'Then commit and push the log update to your next chapter branch.'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body
+            });

--- a/.github/workflows/practice-ci.yml
+++ b/.github/workflows/practice-ci.yml
@@ -1,0 +1,43 @@
+name: Practice CI
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  practice-build:
+    name: Build HIGPractice (iOS 26)
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
+
+      - name: Build
+        run: |
+          xcodebuild \
+            -project practice/HIGPractice/HIGPractice.xcodeproj \
+            -scheme HIGPractice \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+  swiftlint-advisory:
+    name: SwiftLint (Advisory)
+    runs-on: macos-15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict practice/HIGPractice/HIGPractice

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,22 @@
+included:
+  - practice/HIGPractice/HIGPractice
+
+excluded:
+  - practice/HIGPractice/HIGPractice.xcodeproj
+  - practice/HIGPractice/HIGPracticeTests
+  - practice/HIGPractice/HIGPracticeUITests
+
+disabled_rules:
+  - line_length
+  - function_body_length
+  - type_body_length
+  - cyclomatic_complexity
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - operator_usage_whitespace
+  - explicit_init
+  - yoda_condition
+
+reporter: "xcode"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing Guide
+
+This repository follows a chapter-based learning workflow for `practice/HIGPractice`.
+
+## Branch Strategy
+
+- Keep `main` stable.
+- Work in short-lived chapter branches.
+- Branch naming:
+  - `practice/p1-swiftui-ch01`
+  - `practice/p2-cloudkit-ch03`
+
+Start each new chapter branch from updated `main`:
+
+```bash
+scripts/start_chapter_branch.sh --phase p1 --framework swiftui --chapter day2
+```
+
+## Issue -> PR Cycle
+
+1. Create chapter issue using `.github/ISSUE_TEMPLATE/chapter.yml`.
+2. Implement only issue-scoped changes.
+3. Push and open a PR.
+4. Pass CI and review.
+5. Merge (squash) and delete branch.
+6. Write retrospective and update `practice/HIGPractice/LEARNING_LOG.md`.
+
+## Commit Convention
+
+Use Conventional Commits:
+
+- `feat(scope): summary`
+- `fix(scope): summary`
+- `refactor(scope): summary`
+- `docs(scope): summary`
+- `test(scope): summary`
+- `chore(scope): summary`
+
+Examples:
+
+- `feat(practice-home): add adaptive phase grid cards`
+- `feat(chapter): complete swiftui chapter 1 exercises`
+
+## Pull Request Convention
+
+Use `.github/pull_request_template.md`.
+
+PR title format:
+
+- `type(scope): summary`
+
+Examples:
+
+- `feat(practice): finalize setup for learning workflow`
+- `feat(chapter): phase 1 swiftui chapter 1 implementation`
+
+## CI Policy
+
+- Required: `Build HIGPractice (iOS 26)`
+- Advisory: `SwiftLint (Advisory)`
+
+## Local Validation
+
+```bash
+xcodebuild \
+  -project practice/HIGPractice/HIGPractice.xcodeproj \
+  -scheme HIGPractice \
+  -destination 'generic/platform=iOS' \
+  -derivedDataPath /tmp/HIGPracticeDerived \
+  CODE_SIGNING_ALLOWED=NO build
+```
+
+## Labels and Branch Protection
+
+Initialize labels:
+
+```bash
+.github/scripts/setup_labels.sh YuSeongChoi/HIGLab
+```
+
+Apply branch protection (repo admin required):
+
+```bash
+.github/scripts/protect_main_branch.sh YuSeongChoi/HIGLab
+```
+
+## Learning Log Automation
+
+When a PR is merged, `Learning Log Reminder` workflow posts a table row template in the merged PR comments.
+
+You can append one row with:
+
+```bash
+scripts/add_learning_log.sh \
+  --date 2026-02-23 \
+  --phase "Phase 1" \
+  --framework "SwiftUI" \
+  --chapter "Chapter 1" \
+  --issue "#123" \
+  --pr "#124" \
+  --velog "https://velog.io/@..." \
+  --key "State flow from @State to child views"
+```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Apple의 **367개 프레임워크** 중 핵심 50개를 실전 중심으로 학�
 🌐 **라이브 사이트**: [m1zz.github.io/HIGLab](https://m1zz.github.io/HIGLab/)
 
 > 🌱 **주니어 개발자라면?** → [시작 가이드 (GETTING_STARTED.md)](GETTING_STARTED.md)를 먼저 읽어보세요!
+> 🧭 **Practice 학습 워크플로우** → [CONTRIBUTING.md](CONTRIBUTING.md), [practice/HIGPractice/LEARNING_LOG.md](practice/HIGPractice/LEARNING_LOG.md)
 
 ---
 

--- a/practice/HIGPractice/LEARNING_LOG.md
+++ b/practice/HIGPractice/LEARNING_LOG.md
@@ -1,0 +1,28 @@
+# HIGPractice Learning Log
+
+Track each chapter with links to Issue, PR, and retrospective.
+
+## How To Record
+
+For each completed chapter, append one row:
+
+- `Date`: completion date (YYYY-MM-DD)
+- `Phase`: e.g. Phase 1
+- `Framework`: e.g. SwiftUI
+- `Chapter`: e.g. Chapter 1
+- `Issue`: GitHub issue link
+- `PR`: Pull request link
+- `Velog`: retrospective post link
+- `Key Learning`: one concise takeaway
+
+## Log Table
+
+| Date | Phase | Framework | Chapter | Issue | PR | Velog | Key Learning |
+|---|---|---|---|---|---|---|---|
+| 2026-02-23 | Phase 1 | SwiftUI | Chapter 1 | #123 | #124 | https://velog.io/@... | View state flow from `@State` to composition |
+
+## Weekly Reflection (Optional)
+
+- Wins:
+- Blockers:
+- Next week's focus:

--- a/scripts/add_learning_log.sh
+++ b/scripts/add_learning_log.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="practice/HIGPractice/LEARNING_LOG.md"
+
+usage() {
+  cat <<USAGE
+Usage:
+  scripts/add_learning_log.sh \
+    --date YYYY-MM-DD \
+    --phase "Phase 1" \
+    --framework "SwiftUI" \
+    --chapter "Chapter 1" \
+    --issue "#123" \
+    --pr "#124" \
+    --velog "https://velog.io/@..." \
+    --key "State flow from @State to child views"
+USAGE
+}
+
+DATE=""
+PHASE=""
+FRAMEWORK=""
+CHAPTER=""
+ISSUE=""
+PR=""
+VELOG=""
+KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --phase) PHASE="$2"; shift 2 ;;
+    --framework) FRAMEWORK="$2"; shift 2 ;;
+    --chapter) CHAPTER="$2"; shift 2 ;;
+    --issue) ISSUE="$2"; shift 2 ;;
+    --pr) PR="$2"; shift 2 ;;
+    --velog) VELOG="$2"; shift 2 ;;
+    --key) KEY="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+for v in DATE PHASE FRAMEWORK CHAPTER ISSUE PR VELOG KEY; do
+  if [[ -z "${!v}" ]]; then
+    echo "Missing required argument: ${v}"
+    usage
+    exit 1
+  fi
+done
+
+if [[ ! -f "${LOG_FILE}" ]]; then
+  echo "Log file not found: ${LOG_FILE}"
+  exit 1
+fi
+
+ROW="| ${DATE} | ${PHASE} | ${FRAMEWORK} | ${CHAPTER} | ${ISSUE} | ${PR} | ${VELOG} | ${KEY} |"
+
+python3 - "${ROW}" <<'PY'
+import sys
+from pathlib import Path
+
+log_file = Path("practice/HIGPractice/LEARNING_LOG.md")
+row = sys.argv[1]
+
+text = log_file.read_text(encoding="utf-8")
+needle = "|---|---|---|---|---|---|---|---|"
+if needle not in text:
+    raise SystemExit("Could not find table separator row in LEARNING_LOG.md")
+
+text = text.replace(needle, needle + "\n" + row, 1)
+log_file.write_text(text, encoding="utf-8")
+PY
+
+echo "Added row to ${LOG_FILE}"

--- a/scripts/start_chapter_branch.sh
+++ b/scripts/start_chapter_branch.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  scripts/start_chapter_branch.sh \
+    --phase p1 \
+    --framework swiftui \
+    --chapter ch01
+
+Examples:
+  scripts/start_chapter_branch.sh --phase p1 --framework swiftui --chapter day2
+  scripts/start_chapter_branch.sh --phase p2 --framework cloudkit --chapter ch03
+USAGE
+}
+
+PHASE=""
+FRAMEWORK=""
+CHAPTER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase) PHASE="$2"; shift 2 ;;
+    --framework) FRAMEWORK="$2"; shift 2 ;;
+    --chapter) CHAPTER="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+for v in PHASE FRAMEWORK CHAPTER; do
+  if [[ -z "${!v}" ]]; then
+    echo "Missing required argument: ${v}"
+    usage
+    exit 1
+  fi
+done
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is not clean. Commit or stash changes first."
+  exit 1
+fi
+
+normalize() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+PHASE_NORM="$(normalize "$PHASE")"
+FRAMEWORK_NORM="$(normalize "$FRAMEWORK")"
+CHAPTER_NORM="$(normalize "$CHAPTER")"
+
+BRANCH_NAME="practice/${PHASE_NORM}-${FRAMEWORK_NORM}-${CHAPTER_NORM}"
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  git switch main
+fi
+
+git pull origin main
+
+git switch -c "$BRANCH_NAME"
+
+echo "Created branch: $BRANCH_NAME"
+echo "Next steps:"
+echo "  1) Create chapter issue"
+echo "  2) Implement scoped changes"
+echo "  3) Commit + push + PR"


### PR DESCRIPTION
## Summary
- Add Issue and PR templates for chapter-based learning workflow
- Add `Practice CI` workflow (required build + advisory swiftlint)
- Add repository scripts for label setup and main branch protection
- Add learning log automation:
  - merged PR reminder workflow
  - `scripts/add_learning_log.sh` one-line row append tool
  - `scripts/start_chapter_branch.sh` (update main + create next chapter branch)
- Add `CONTRIBUTING.md` and `practice/HIGPractice/LEARNING_LOG.md`
- Add workflow discoverability link in `README.md`

## Why
- Standardize the cycle: issue -> chapter branch -> PR -> merge -> retrospective
- Reduce repetitive manual steps and keep chapter history consistent

## Scope
- `.github/**`
- `scripts/**`
- `CONTRIBUTING.md`
- `practice/HIGPractice/LEARNING_LOG.md`
- `README.md`

## Testing
- Verified shell script syntax:
  - `bash -n .github/scripts/protect_main_branch.sh scripts/add_learning_log.sh scripts/start_chapter_branch.sh`
- Verified utility help output:
  - `scripts/add_learning_log.sh --help`
  - `scripts/start_chapter_branch.sh --help`

## Checklist
- [x] Templates added
- [x] CI workflow added
- [x] Learning log automation added
- [x] Contributor guide added

## Follow-up
- Re-authenticate `gh` token if branch-protection API call fails locally
- Apply branch protection: `.github/scripts/protect_main_branch.sh YuSeongChoi/HIGLab main "Build HIGPractice (iOS 26)"`
